### PR TITLE
chore: rename lenster to hey

### DIFF
--- a/apps/web/src/components/Common/VideoCard/ShareModal.tsx
+++ b/apps/web/src/components/Common/VideoCard/ShareModal.tsx
@@ -53,8 +53,8 @@ const ShareModal: FC<Props> = ({ show, setShowShare, video }) => {
             className="rounded-full"
             target="_blank"
             rel="noreferrer"
-            onClick={() => Analytics.track(TRACK.PUBLICATION.SHARE.LENSTER)}
-            href={getSharableLink('lenster', video)}
+            onClick={() => Analytics.track(TRACK.PUBLICATION.SHARE.HEY)}
+            href={getSharableLink('hey', video)}
           >
             <img
               src={imageCdn(
@@ -63,7 +63,7 @@ const ShareModal: FC<Props> = ({ show, setShowShare, video }) => {
               )}
               className="h-10 w-10 max-w-none rounded-full"
               loading="eager"
-              alt="lenster"
+              alt="hey"
               draggable={false}
             />
           </Link>

--- a/packages/constants/general.ts
+++ b/packages/constants/general.ts
@@ -126,7 +126,7 @@ export const LENSTUBE_APP_ID = 'lenstube'
 export const LENSTUBE_BYTES_APP_ID = 'lenstube-bytes'
 export const ALLOWED_APP_IDS = [
   'orb',
-  'lenster',
+  'hey',
   'buttrfly',
   'lensplay',
   'diversehq'
@@ -167,9 +167,9 @@ export const LENSPROTOCOL_HANDLE = 'lensprotocol'
 export const HANDLE_SUFFIX = IS_MAINNET ? '.lens' : '.test'
 
 // other apps
-export const LENSTER_WEBSITE_URL = IS_MAINNET
-  ? 'https://lenster.xyz'
-  : 'https://testnet.lenster.xyz'
+export const HEY_WEBSITE_URL = IS_MAINNET
+  ? 'https://hey.xyz'
+  : 'https://testnet.hey.xyz'
 
 // analytics
 export const MIXPANEL_API_HOST = '/collect'

--- a/packages/helpers/browser/analytics.ts
+++ b/packages/helpers/browser/analytics.ts
@@ -31,7 +31,7 @@ export const TRACK = {
     },
     PERMALINK: 'Permalink publication',
     SHARE: {
-      LENSTER: 'Share to Lenster',
+      HEY: 'Share to Hey',
       X: 'Share to X',
       REDDIT: 'Share to Reddit',
       LINKEDIN: 'Share to LinkedIn'

--- a/packages/helpers/generic/functions/getSharableLink.ts
+++ b/packages/helpers/generic/functions/getSharableLink.ts
@@ -1,5 +1,5 @@
 import {
-  LENSTER_WEBSITE_URL,
+  HEY_WEBSITE_URL,
   LENSTUBE_APP_NAME,
   LENSTUBE_WEBSITE_URL,
   LENSTUBE_X_HANDLE
@@ -10,7 +10,7 @@ const getViewUrl = (video: Publication) => {
   return `${LENSTUBE_WEBSITE_URL}/watch/${video.id}`
 }
 
-type Link = 'lenstube' | 'lenster' | 'x' | 'reddit' | 'linkedin'
+type Link = 'lenstube' | 'hey' | 'x' | 'reddit' | 'linkedin'
 
 export const getSharableLink = (link: Link, video: Publication) => {
   const { handle } = video.profile
@@ -18,8 +18,8 @@ export const getSharableLink = (link: Link, video: Publication) => {
 
   if (link === 'lenstube') {
     return `${LENSTUBE_WEBSITE_URL}/watch/${video.id}`
-  } else if (link === 'lenster') {
-    return `${LENSTER_WEBSITE_URL}/?url=${getViewUrl(video)}&text=${
+  } else if (link === 'hey') {
+    return `${HEY_WEBSITE_URL}/?url=${getViewUrl(video)}&text=${
       (metadata?.name as string) ?? ''
     } by @${handle}&hashtags=Lenstube&preview=true`
   } else if (link === 'x') {


### PR DESCRIPTION
We just rebranded lenster.xyz to hey.xyz

https://twitter.com/heydotxyz/status/1707431312385253477